### PR TITLE
Fixing dual swords with 2 elements

### DIFF
--- a/static/include.js
+++ b/static/include.js
@@ -116,7 +116,7 @@ var calculatingPalico = angular.module('calculatingPalico', ['ui.bootstrap'])
 					etype = elements[0].id;
 				}
 				if (elements[1].id < 6) {
-					epwr = ePwr(elements[1].attack, sharpnessModE[sharpness]);
+					epwr2 = ePwr(elements[1].attack, sharpnessModE[sharpness]);
 					etype2 = elements[1].id;
 				}
 			}


### PR DESCRIPTION
Dual swords with 2 elements always display 0 for the second element. This was caused by epwr being set where epwr2 was supposed to be, leaving epwr2 always 0.